### PR TITLE
Replace GCS with Storage firebase-admin + Functions Test Coverage up to ~70%

### DIFF
--- a/functions/package.json
+++ b/functions/package.json
@@ -18,7 +18,6 @@
     "logs": "firebase functions:log"
   },
   "dependencies": {
-    "@google-cloud/storage": "^1.7.0",
     "algoliasearch": "^3.24.6",
     "babel-core": "^6.26.0",
     "babel-plugin-module-resolver": "^3.1.1",

--- a/functions/src/actionRunner/actions.js
+++ b/functions/src/actionRunner/actions.js
@@ -1,12 +1,8 @@
 import { invoke, get } from 'lodash'
-import {
-  slashPathToFirestoreRef,
-  dataByIdSnapshot,
-  batchCopyBetweenFirestoreRefs
-} from './utils'
+import { dataByIdSnapshot, batchCopyBetweenFirestoreRefs } from './utils'
 import { downloadFromStorage, uploadToStorage } from '../utils/cloudStorage'
 import { to } from '../utils/async'
-
+import { slashPathToFirestoreRef } from '../utils/firestore'
 /**
  * Copy data between Firestore instances from two different Firebase projects
  * @param  {firebase.App} app1 - First app for the action

--- a/functions/src/actionRunner/runAction.js
+++ b/functions/src/actionRunner/runAction.js
@@ -10,6 +10,9 @@ import {
 /**
  * Run action based on action template. Multiple Service Account Types
  * supported (i.e. stored on Firestore or cloud storage)
+ * @param  {functions.database.DataSnapshot} snap - Data snapshot from cloud function
+ * @param  {functions.EventContext} context - The context in which an event occurred
+ * @param  {Object} context.params - Parameters from event
  */
 export default async function runAction(snap, context) {
   const eventData = snap.val() || {}

--- a/functions/src/actionRunner/utils.js
+++ b/functions/src/actionRunner/utils.js
@@ -249,10 +249,9 @@ async function getSubcollectionNames(subcollectionSetting, ref) {
   return collectionsSnapToArray(collections)
 }
 
+const MAX_DOCS_PER_BATCH = 500
+
 async function writeDocBatch({ dataFromSrc, destRef, opts }) {
-  if (!destRef.firestore.batch) {
-    throw new Error(JSON.stringify(Object.keys(destRef.firestore)))
-  }
   const batch = destRef.firestore.batch()
   const srcChildIds = []
   // Call set to dest instance for each doc within the original data
@@ -271,7 +270,6 @@ async function writeDocBatch({ dataFromSrc, destRef, opts }) {
   }
   return writeRes
 }
-const MAX_DOCS_PER_BATCH = 500
 
 /**
  * Write documents to Firestore in batches. If there are more docs than

--- a/functions/src/actionRunner/utils.js
+++ b/functions/src/actionRunner/utils.js
@@ -1,8 +1,7 @@
-import { size, isArray } from 'lodash'
+import { size, chunk, flatten, isArray } from 'lodash'
 import * as admin from 'firebase-admin'
 import { ACTION_RUNNER_RESPONSES_PATH } from './constants'
-import { to } from '../utils/async'
-import { writeDocsInBatches } from '../utils/firestore'
+import { to, promiseWaterfall } from '../utils/async'
 
 /**
  * Create data object with values for each document with keys being doc.id.
@@ -248,6 +247,62 @@ async function getSubcollectionNames(subcollectionSetting, ref) {
     throw getCollectionsErr
   }
   return collectionsSnapToArray(collections)
+}
+
+async function writeDocBatch({ dataFromSrc, destRef, opts }) {
+  if (!destRef.firestore.batch) {
+    throw new Error(JSON.stringify(Object.keys(destRef.firestore)))
+  }
+  const batch = destRef.firestore.batch()
+  const srcChildIds = []
+  // Call set to dest instance for each doc within the original data
+  dataFromSrc.forEach(({ id, data }) => {
+    const childRef = destRef.doc(id)
+    srcChildIds.push(id)
+    batch.set(childRef, data, opts)
+  })
+  const [writeErr, writeRes] = await to(batch.commit())
+  // Handle errors in batch write
+  if (writeErr) {
+    console.error('Error writing batch ', writeErr.message || writeErr, {
+      destId: destRef.id
+    })
+    throw writeErr
+  }
+  return writeRes
+}
+const MAX_DOCS_PER_BATCH = 500
+
+/**
+ * Write documents to Firestore in batches. If there are more docs than
+ * the max docs per batch count, multiple batches will be run in succession.
+ * @param  {firestore.Firestore} firestoreInstance - Instance on which to
+ * create ref
+ * @param  {String} destPath - Destination path under which data should be
+ * written
+ * @param  {Array} docData - List of docs to be written
+ * @param  {Object} opts - Options object (can contain merge)
+ * @return {Promise} Resolves with results of batch commit
+ */
+export async function writeDocsInBatches({ dataFromSrc, destRef, opts }) {
+  // Check if doc data is longer than max docs per batch
+  if (dataFromSrc && dataFromSrc.length < MAX_DOCS_PER_BATCH) {
+    // Less than the max number of docs in a batch
+    return writeDocBatch({ dataFromSrc, destRef, opts })
+  }
+  // More than max number of docs per batch - run multiple batches in succession
+  const promiseResult = await promiseWaterfall(
+    chunk(dataFromSrc, MAX_DOCS_PER_BATCH).map((dataChunk, chunkIdx) => {
+      // Return a function to fit promise waterfall pattern
+      return () => {
+        console.log(`Writing chunk #${chunkIdx} to ${destRef.id}`)
+        return writeDocBatch({ dataFromSrc: dataChunk, destRef, opts })
+      }
+    })
+  )
+  // Flatten array of arrays (one for each chunk) into an array of results
+  // and wrap in promise resolve
+  return flatten(promiseResult)
 }
 
 /**

--- a/functions/src/utils/cloudStorage.js
+++ b/functions/src/utils/cloudStorage.js
@@ -3,9 +3,6 @@ import path from 'path'
 import fs from 'fs-extra'
 import mkdirp from 'mkdirp-promise'
 import * as admin from 'firebase-admin'
-const gcs = require('@google-cloud/storage')()
-
-const functionsConfig = JSON.parse(process.env.FIREBASE_CONFIG)
 
 /**
  * Download JSON File from Google Cloud Storage and return is contents
@@ -18,9 +15,7 @@ export async function downloadFromStorage(app, pathInStorage) {
     throw new Error('Storage is not enabled on firebase-admin')
   }
   // Handle default app
-  const bucket = !app
-    ? gcs.bucket(functionsConfig.storageBucket)
-    : app.storage().bucket
+  const bucket = !app ? admin.storage().bucket : app.storage().bucket
   const localPath = `actions/storage/${pathInStorage}/${Date.now()}.json`
   const tempLocalPath = path.join(os.tmpdir(), localPath)
   const tempLocalDir = path.dirname(tempLocalPath)

--- a/functions/src/utils/cloudStorage.js
+++ b/functions/src/utils/cloudStorage.js
@@ -15,7 +15,7 @@ export async function downloadFromStorage(app, pathInStorage) {
     throw new Error('Storage is not enabled on firebase-admin')
   }
   // Handle default app
-  const bucket = !app ? admin.storage().bucket : app.storage().bucket
+  const bucket = !app ? admin.storage().bucket() : app.storage().bucket()
   const localPath = `actions/storage/${pathInStorage}/${Date.now()}.json`
   const tempLocalPath = path.join(os.tmpdir(), localPath)
   const tempLocalDir = path.dirname(tempLocalPath)

--- a/functions/src/utils/encryption.js
+++ b/functions/src/utils/encryption.js
@@ -13,15 +13,18 @@ import * as functions from 'firebase-functions'
  * by default if not passed.
  */
 export function encrypt(text, options = {}) {
-  const { algorithm = 'aes-256-ctr', password } = options
+  const { algorithm = 'aes-256-ctr', password: passwordOption } = options
   if (!text) {
     return
   }
   const str = !isString(text) ? JSON.stringify(text) : text
-  const cipher = crypto.createCipher(
-    algorithm,
-    password || functions.config().encryption.password
-  )
+  const password = passwordOption || functions.config().encryption.password
+  if (!password) {
+    throw new Error(
+      'Password is required to encrypt. Check functions config for encryption.password'
+    )
+  }
+  const cipher = crypto.createCipher(algorithm, password)
   let crypted = cipher.update(str, 'utf8', 'hex')
   crypted += cipher.final('hex')
   return crypted

--- a/functions/src/utils/firestore.js
+++ b/functions/src/utils/firestore.js
@@ -1,4 +1,4 @@
-import { size, chunk, filter, isFunction } from 'lodash'
+import { size, chunk, filter, isFunction, flatten } from 'lodash'
 import { to, promiseWaterfall } from '../utils/async'
 
 /**
@@ -117,7 +117,7 @@ export function writeDocsInBatches(firestoreInstance, destPath, docData, opts) {
   }
   const docChunks = chunk(docData, MAX_DOCS_PER_BATCH)
   // More than max number of docs per batch - run multiple batches in succession
-  return promiseWaterfall(
+  const promiseResult = promiseWaterfall(
     docChunks.map((dataChunk, chunkIdx) => {
       console.log(
         `Writing chunk #${chunkIdx} of ${
@@ -127,6 +127,9 @@ export function writeDocsInBatches(firestoreInstance, destPath, docData, opts) {
       return () => batchWriteDocs(firestoreInstance, destPath, dataChunk, opts)
     })
   )
+  // Flatten array of arrays (one for each chunk) into an array of results
+  // and wrap in promise resolve
+  return flatten(promiseResult)
 }
 
 /**

--- a/functions/src/utils/firestore.js
+++ b/functions/src/utils/firestore.js
@@ -104,7 +104,12 @@ const MAX_DOCS_PER_BATCH = 500
  * @param  {Object} opts - Options object (can contain merge)
  * @return {Promise} Resolves with results of batch commit
  */
-export function writeDocsInBatches(firestoreInstance, destPath, docData, opts) {
+export async function writeDocsInBatches(
+  firestoreInstance,
+  destPath,
+  docData,
+  opts
+) {
   // Check if doc data is longer than max docs per batch
   if (docData && docData.length < MAX_DOCS_PER_BATCH) {
     console.log(
@@ -117,14 +122,16 @@ export function writeDocsInBatches(firestoreInstance, destPath, docData, opts) {
   }
   const docChunks = chunk(docData, MAX_DOCS_PER_BATCH)
   // More than max number of docs per batch - run multiple batches in succession
-  const promiseResult = promiseWaterfall(
+  const promiseResult = await promiseWaterfall(
     docChunks.map((dataChunk, chunkIdx) => {
-      console.log(
-        `Writing chunk #${chunkIdx} of ${
-          docChunks.length
-        } for path: ${destPath}`
-      )
-      return () => batchWriteDocs(firestoreInstance, destPath, dataChunk, opts)
+      return () => {
+        console.log(
+          `Writing chunk #${chunkIdx} of ${
+            docChunks.length
+          } for path: ${destPath}`
+        )
+        return batchWriteDocs(firestoreInstance, destPath, dataChunk, opts)
+      }
     })
   )
   // Flatten array of arrays (one for each chunk) into an array of results

--- a/functions/src/utils/serviceAccounts.js
+++ b/functions/src/utils/serviceAccounts.js
@@ -9,9 +9,6 @@ import mkdirp from 'mkdirp-promise'
 import { decrypt } from './encryption'
 import { to } from './async'
 
-const gcs = require('@google-cloud/storage')()
-
-const functionsConfig = JSON.parse(process.env.FIREBASE_CONFIG)
 const missingCredMsg =
   'Credential parameter is required to load service account from Firestore'
 
@@ -159,8 +156,11 @@ export async function serviceAccountFromStoragePath(docPath, name) {
   // Create Temporary directory and download file to that folder
   await mkdirp(tempLocalDir)
   // Download file from bucket to local filesystem
-  const bucket = gcs.bucket(functionsConfig.storageBucket)
-  await bucket.file(docPath).download({ destination: tempLocalPath })
+  await admin
+    .storage()
+    .bucket()
+    .file(docPath)
+    .download({ destination: tempLocalPath })
   return tempLocalPath
 }
 

--- a/functions/test/unit/actionRunner.spec.js
+++ b/functions/test/unit/actionRunner.spec.js
@@ -20,7 +20,12 @@ describe('actionRunner RTDB Cloud Function (RTDB:onCreate)', function() {
     // Stub Firebase's admin.initializeApp()
     const firestoreStub = sinon.stub().returns({
       collection: sinon.stub().returns({
-        get: sinon.stub().returns(Promise.resolve({ data: () => ({}) }))
+        get: sinon.stub().returns(Promise.resolve({ data: () => ({}) })),
+        firestore: {
+          batch: sinon
+            .stub()
+            .returns({ commit: sinon.stub().returns(Promise.resolve()) })
+        }
       })
     })
     firestoreStub.batch = sinon.stub().returns({
@@ -67,9 +72,10 @@ describe('actionRunner RTDB Cloud Function (RTDB:onCreate)', function() {
           })
         )
       })
-    collectionStub = sinon
-      .stub()
-      .returns({ add: sinon.stub().returns(Promise.resolve({})), doc: docStub })
+    collectionStub = sinon.stub().returns({
+      add: sinon.stub().returns(Promise.resolve({})),
+      doc: docStub
+    })
 
     // Create Firestore stub out of stubbed methods
     const firestoreStub = sinon

--- a/functions/test/unit/actionRunner.spec.js
+++ b/functions/test/unit/actionRunner.spec.js
@@ -479,8 +479,7 @@ describe('actionRunner RTDB Cloud Function (RTDB:onCreate)', function() {
     })
   })
 
-  // TODO: Unskip by passing a valid encrypted object
-  it.skip('Works with backups', async () => {
+  it('Works with backups', async () => {
     const snap = {
       val: () => ({
         projectId: 'test',
@@ -493,25 +492,21 @@ describe('actionRunner RTDB Cloud Function (RTDB:onCreate)', function() {
       params: { pushId: 1 }
     }
     // Invoke with fake event object
-    const [err] = await to(actionRunner(snap, fakeContext))
+    const res = await actionRunner(snap, fakeContext)
     // Response marked as started
     expect(setStub).to.have.been.calledWith({
       startedAt: 'test',
       status: 'started'
     })
-    // Confir error thrown with correct message
-    expect(err).to.have.property(
-      'message',
-      'Steps array was not provided to action request'
-    )
+    // Confirm res
+    expect(res).to.be.undefined
     // Ref for response is correct path
     expect(refStub).to.have.been.calledWith(responsePath)
-    // Error object written to response
+    // Success object written to response
     expect(setStub).to.have.been.calledWith({
       completed: true,
       completedAt: 'test',
-      error: 'Steps array was not provided to action request',
-      status: 'error'
+      status: 'success'
     })
   })
 })

--- a/functions/test/unit/actionRunner.spec.js
+++ b/functions/test/unit/actionRunner.spec.js
@@ -1,6 +1,7 @@
 import * as admin from 'firebase-admin'
 import { to } from 'utils/async'
 import { encrypt } from 'utils/encryption'
+import fs from 'fs'
 
 const responsePath = 'responses/actionRunner/1'
 const createdAt = 'timestamp'
@@ -15,31 +16,60 @@ describe('actionRunner RTDB Cloud Function (RTDB:onCreate)', function() {
   let refStub
   let docStub
   let collectionStub
+  let parentStorageStub
+  let parentFirestoreStub
 
   before(() => {
-    // Stub Firebase's admin.initializeApp()
-    const firestoreStub = sinon.stub().returns({
-      collection: sinon.stub().returns({
-        get: sinon.stub().returns(Promise.resolve({ data: () => ({}) })),
-        firestore: {
-          batch: sinon
-            .stub()
-            .returns({ commit: sinon.stub().returns(Promise.resolve()) })
-        }
+    parentStorageStub = sinon.stub().returns({
+      bucket: sinon.stub().returns({
+        file: sinon.stub().returns({
+          delete: sinon.stub().returns(Promise.resolve({})),
+          // Mock download method with invalid JSON file data
+          download: sinon.spy(({ destination }) => {
+            fs.writeFileSync(
+              destination,
+              JSON.stringify({ asdf: 'asdf' }, null, 2)
+            )
+            return Promise.resolve({ asdf: 'asdf' })
+          })
+        }),
+        upload: sinon.stub().returns(Promise.resolve({}))
       })
     })
-    firestoreStub.batch = sinon.stub().returns({
+    // Stub Firebase's admin.initializeApp()
+    parentFirestoreStub = sinon.stub().returns({
+      collection: sinon.stub().returns({
+        get: sinon
+          .stub()
+          .returns(
+            Promise.resolve({ data: () => ({ some: 'value' }), exists: true })
+          ),
+        firestore: {
+          batch: sinon.stub().returns({
+            commit: sinon.stub().returns(Promise.resolve()),
+            set: sinon.stub().returns({})
+          })
+        },
+        doc: sinon.stub().returns({})
+      }),
+      doc: sinon.stub().returns({
+        update: sinon.stub().returns(Promise.resolve())
+      })
+    })
+
+    parentFirestoreStub.batch = sinon.stub().returns({
       set: sinon.stub().returns(Promise.resolve()),
       commit: sinon.stub().returns(Promise.resolve())
     })
     adminInitStub = sinon.stub(admin, 'initializeApp').returns({
-      firestore: firestoreStub,
+      firestore: parentFirestoreStub,
       database: sinon.stub().returns({
         ref: sinon.stub().returns({
           once: sinon.stub().returns(Promise.resolve({ val: () => ({}) })),
           update: sinon.stub().returns(Promise.resolve())
         })
-      })
+      }),
+      storage: parentStorageStub
     })
     sinon.stub(admin.credential, 'cert')
   })
@@ -107,439 +137,450 @@ describe('actionRunner RTDB Cloud Function (RTDB:onCreate)', function() {
     functionsTest.cleanup()
   })
 
-  it('Throws and updates error if projectId is undefined', async () => {
-    const snap = {
-      val: () => ({})
-    }
-    const fakeContext = {
-      params: { pushId: 1 }
-    }
-    // Invoke with fake event object
-    const [err] = await to(actionRunner(snap, fakeContext))
-    // Confir error thrown with correct message
-    expect(err).to.have.property('message', 'projectId parameter is required')
-    // Ref for response is correct path
-    expect(refStub).to.have.been.calledWith(responsePath)
-    // Error object written to response
-    expect(setStub).to.have.been.calledOnce
-  })
+  describe('Invalid Action Template', () => {
+    it('Throws and updates error if projectId is undefined', async () => {
+      const snap = {
+        val: () => ({})
+      }
+      const fakeContext = {
+        params: { pushId: 1 }
+      }
+      // Invoke with fake event object
+      const [err] = await to(actionRunner(snap, fakeContext))
+      // Confir error thrown with correct message
+      expect(err).to.have.property('message', 'projectId parameter is required')
+      // Ref for response is correct path
+      expect(refStub).to.have.been.calledWith(responsePath)
+      // Error object written to response
+      expect(setStub).to.have.been.calledOnce
+    })
 
-  it('Throws if action template is not included', async () => {
-    const snap = {
-      val: () => ({ projectId: 'test' }),
-      ref: refStub()
-    }
-    const fakeContext = {
-      params: { pushId: 1 }
-    }
-    // Invoke with fake event object
-    const [err] = await to(actionRunner(snap, fakeContext))
-    // Response marked as started
-    expect(setStub).to.have.been.calledWith({
-      startedAt: 'test',
-      status: 'started'
-    })
-    // Confir error thrown with correct message
-    expect(err).to.have.property(
-      'message',
-      'Action template is required to run steps'
-    )
-    // Ref for response is correct path
-    expect(refStub).to.have.been.calledWith(responsePath)
-    // Error object written to response
-    expect(setStub).to.have.been.calledWith({
-      completed: true,
-      completedAt: 'test',
-      error: 'Action template is required to run steps',
-      status: 'error'
-    })
-  })
-
-  it('Throws if action template is not an object', async () => {
-    const snap = {
-      val: () => ({ projectId: 'test', template: 'asdf' }),
-      ref: refStub()
-    }
-    const fakeContext = {
-      params: { pushId: 1 }
-    }
-    // Invoke with fake event object
-    const [err] = await to(actionRunner(snap, fakeContext))
-    // Response marked as started
-    expect(setStub).to.have.been.calledWith({
-      startedAt: 'test',
-      status: 'started'
-    })
-    // Confir error thrown with correct message
-    expect(err).to.have.property(
-      'message',
-      'Action template is required to run steps'
-    )
-    // Ref for response is correct path
-    expect(refStub).to.have.been.calledWith(responsePath)
-    // Error object written to response
-    expect(setStub).to.have.been.calledWith({
-      completed: true,
-      completedAt: 'test',
-      error: 'Action template is required to run steps',
-      status: 'error'
-    })
-  })
-
-  it('Throws if action template does not contain steps', async () => {
-    const snap = {
-      val: () => ({ projectId: 'test', template: { asdf: 'asdf' } }),
-      ref: refStub()
-    }
-    const fakeContext = {
-      params: { pushId: 1 }
-    }
-    // Invoke with fake event object
-    const [err] = await to(actionRunner(snap, fakeContext))
-    // Response marked as started
-    expect(setStub).to.have.been.calledWith({
-      startedAt: 'test',
-      status: 'started'
-    })
-    // Confir error thrown with correct message
-    expect(err).to.have.property(
-      'message',
-      'Steps array was not provided to action request'
-    )
-    // Ref for response is correct path
-    expect(refStub).to.have.been.calledWith(responsePath)
-    // Error object written to response
-    expect(setStub).to.have.been.calledWith({
-      completed: true,
-      completedAt: 'test',
-      error: 'Steps array was not provided to action request',
-      status: 'error'
-    })
-  })
-
-  it('Throws if action template does not contain inputs', async () => {
-    const snap = {
-      val: () => ({ projectId: 'test', template: { steps: [] } }),
-      ref: refStub()
-    }
-    const fakeContext = {
-      params: { pushId: 1 }
-    }
-    // Invoke with fake event object
-    const [err] = await to(actionRunner(snap, fakeContext))
-    // Response marked as started
-    expect(setStub).to.have.been.calledWith({
-      startedAt: 'test',
-      status: 'started'
-    })
-    // Confir error thrown with correct message
-    expect(err).to.have.property(
-      'message',
-      'Inputs array was not provided to action request'
-    )
-    // Ref for response is correct path
-    expect(refStub).to.have.been.calledWith(responsePath)
-    // Error object written to response
-    expect(setStub).to.have.been.calledWith({
-      completed: true,
-      completedAt: 'test',
-      error: 'Inputs array was not provided to action request',
-      status: 'error'
-    })
-  })
-
-  it('Throws if action template does not contain inputValues', async () => {
-    const snap = {
-      val: () => ({ projectId: 'test', template: { steps: [], inputs: [] } }),
-      ref: refStub()
-    }
-    const fakeContext = {
-      params: { pushId: 1 }
-    }
-    // Invoke with fake event object
-    const [err] = await to(actionRunner(snap, fakeContext))
-    // Response marked as started
-    expect(setStub).to.have.been.calledWith({
-      startedAt: 'test',
-      status: 'started'
-    })
-    // Confir error thrown with correct message
-    expect(err).to.have.property(
-      'message',
-      'Input values array was not provided to action request'
-    )
-    // Ref for response is correct path
-    expect(refStub).to.have.been.calledWith(responsePath)
-    // Error object written to response
-    expect(setStub).to.have.been.calledWith({
-      completed: true,
-      completedAt: 'test',
-      error: 'Input values array was not provided to action request',
-      status: 'error'
-    })
-  })
-
-  it('Throws if inputValues are not passed', async () => {
-    const snap = {
-      val: () => ({
-        projectId: 'test',
-        template: { steps: [], inputs: [] }
-      }),
-      ref: refStub()
-    }
-    const fakeContext = {
-      params: { pushId: 1 }
-    }
-    // Invoke with fake event object
-    const [err] = await to(actionRunner(snap, fakeContext))
-    // Response marked as started
-    expect(setStub).to.have.been.calledWith({
-      startedAt: 'test',
-      status: 'started'
-    })
-    // Confir error thrown with correct message
-    expect(err).to.have.property(
-      'message',
-      'Input values array was not provided to action request'
-    )
-    // Ref for response is correct path
-    expect(refStub).to.have.been.calledWith(responsePath)
-    // Error object written to response
-    expect(setStub).to.have.been.calledWith({
-      completed: true,
-      completedAt: 'test',
-      error: 'Input values array was not provided to action request',
-      status: 'error'
-    })
-  })
-
-  it('Throws if environment does not have databaseURL', async () => {
-    const snap = {
-      val: () => ({
-        projectId: 'test',
-        inputValues: [],
-        environments: [{ type: 'test' }],
-        template: { steps: [], inputs: [] }
-      }),
-      ref: refStub()
-    }
-    const fakeContext = {
-      params: { pushId: 1 }
-    }
-    // Invoke with fake event object
-    const [err] = await to(actionRunner(snap, fakeContext))
-    // Response marked as started
-    expect(setStub).to.have.been.calledWith({
-      startedAt: 'test',
-      status: 'started'
-    })
-    // Confir error thrown with correct message
-    expect(err).to.have.property(
-      'message',
-      'databaseURL is required for action to authenticate through serviceAccount'
-    )
-    // Ref for response is correct path
-    expect(refStub).to.have.been.calledWith(responsePath)
-    // Error object written to response
-    expect(setStub).to.have.been.calledWith({
-      completed: true,
-      completedAt: 'test',
-      error:
-        'databaseURL is required for action to authenticate through serviceAccount',
-      status: 'error'
-    })
-  })
-
-  it('Throws if environment does not an environment key or id', async () => {
-    const snap = {
-      val: () => ({
-        projectId: 'test',
-        inputValues: [],
-        environments: [{ databaseURL: 'https://some-project.firebaseio.com' }],
-        template: { steps: [], inputs: [] }
-      }),
-      ref: refStub()
-    }
-    const fakeContext = {
-      params: { pushId: 1 }
-    }
-    // Invoke with fake event object
-    const [err] = await to(actionRunner(snap, fakeContext))
-    // Response marked as started
-    expect(setStub).to.have.been.calledWith({
-      startedAt: 'test',
-      status: 'started'
-    })
-    // Confir error thrown with correct message
-    expect(err).to.have.property(
-      'message',
-      'environmentKey or id is required for action to authenticate through serviceAccount'
-    )
-    // Ref for response is correct path
-    expect(refStub).to.have.been.calledWith(responsePath)
-    // Error object written to response
-    expect(setStub).to.have.been.calledWith({
-      completed: true,
-      completedAt: 'test',
-      error:
-        'environmentKey or id is required for action to authenticate through serviceAccount',
-      status: 'error'
-    })
-  })
-
-  it('Throws if project does not contain serviceAccount', async () => {
-    const id = 'asdf'
-    const projectId = 'another'
-    const snap = {
-      val: () => ({
-        projectId,
-        inputValues: [],
-        environments: [
-          { databaseURL: 'https://some-project.firebaseio.com', id }
-        ],
-        template: { steps: [], inputs: [] }
-      }),
-      ref: refStub()
-    }
-    const fakeContext = {
-      params: { pushId: 1 }
-    }
-    // Invoke with fake event object
-    const [err] = await to(actionRunner(snap, fakeContext))
-    // Response marked as started
-    expect(setStub).to.have.been.calledWith({
-      startedAt: 'test',
-      status: 'started'
-    })
-    // Confir error thrown with correct message
-    expect(err).to.have.property(
-      'message',
-      `Project containing service account not at path: projects/${projectId}/environments/${id}`
-    )
-    // Ref for response is correct path
-    expect(refStub).to.have.been.calledWith(responsePath)
-    // Error object written to response
-    expect(setStub).to.have.been.calledWith({
-      completed: true,
-      completedAt: 'test',
-      error: `Project containing service account not at path: projects/${projectId}/environments/${id}`,
-      status: 'error'
-    })
-  })
-
-  it('Throws if provided an invalid service account object (i.e. a string that is not an encrypted object)', async () => {
-    const snap = {
-      val: () => ({
-        projectId: existingProjectId,
-        inputValues: [],
-        environments: [
-          { databaseURL: 'https://some-project.firebaseio.com', id: 'asdf' }
-        ],
-        template: { steps: [], inputs: [] }
-      }),
-      ref: refStub()
-    }
-    const fakeContext = {
-      params: { pushId: 1 }
-    }
-    // Invoke with fake event object
-    const [err] = await to(actionRunner(snap, fakeContext))
-    // Response marked as started
-    expect(setStub).to.have.been.calledWith({
-      startedAt: 'test',
-      status: 'started'
-    })
-    // Confir error thrown with correct message
-    expect(err).to.have.property(
-      'message',
-      'Service account not a valid object'
-    )
-    // Ref for response is correct path
-    expect(refStub).to.have.been.calledWith(responsePath)
-    // Error object written to response
-    expect(setStub).to.have.been.calledWith({
-      completed: true,
-      completedAt: 'test',
-      error: 'Service account not a valid object',
-      status: 'error'
-    })
-  })
-
-  it('Throws if template contains invalid steps', async () => {
-    const validProjectId = 'aosidjfoaisjdfoi'
-    docStub.withArgs(`projects/${validProjectId}/environments/asdf`).returns({
-      get: sinon.stub().returns(
-        Promise.resolve({
-          data: () => ({
-            serviceAccount: {
-              credential: encrypt({
-                type: 'service_account',
-                project_id: 'asdf',
-                private_key_id: 'asdf',
-                private_key: 'asdf',
-                client_email: 'asdf',
-                client_id: 'sadf',
-                auth_uri: 'https://accounts.google.com/o/oauth2/auth',
-                token_uri: 'https://accounts.google.com/o/oauth2/token',
-                auth_provider_x509_cert_url:
-                  'https://www.googleapis.com/oauth2/v1/certs',
-                client_x509_cert_url: 'asdf'
-              })
-            }
-          }),
-          exists: true
-        })
+    it('Throws if action template is not included', async () => {
+      const snap = {
+        val: () => ({ projectId: 'test' }),
+        ref: refStub()
+      }
+      const fakeContext = {
+        params: { pushId: 1 }
+      }
+      // Invoke with fake event object
+      const [err] = await to(actionRunner(snap, fakeContext))
+      // Response marked as started
+      expect(setStub).to.have.been.calledWith({
+        startedAt: 'test',
+        status: 'started'
+      })
+      // Confir error thrown with correct message
+      expect(err).to.have.property(
+        'message',
+        'Action template is required to run steps'
       )
+      // Ref for response is correct path
+      expect(refStub).to.have.been.calledWith(responsePath)
+      // Error object written to response
+      expect(setStub).to.have.been.calledWith({
+        completed: true,
+        completedAt: 'test',
+        error: 'Action template is required to run steps',
+        status: 'error'
+      })
     })
-    const snap = {
-      val: () => ({
-        projectId: validProjectId,
-        inputValues: ['projects'],
-        environments: [
-          {
-            databaseURL: 'https://some-project.firebaseio.com',
-            id: 'asdf'
-          }
-        ],
-        template: {
-          steps: [
+
+    it('Throws if action template is not an object', async () => {
+      const snap = {
+        val: () => ({ projectId: 'test', template: 'asdf' }),
+        ref: refStub()
+      }
+      const fakeContext = {
+        params: { pushId: 1 }
+      }
+      // Invoke with fake event object
+      const [err] = await to(actionRunner(snap, fakeContext))
+      // Response marked as started
+      expect(setStub).to.have.been.calledWith({
+        startedAt: 'test',
+        status: 'started'
+      })
+      // Confir error thrown with correct message
+      expect(err).to.have.property(
+        'message',
+        'Action template is required to run steps'
+      )
+      // Ref for response is correct path
+      expect(refStub).to.have.been.calledWith(responsePath)
+      // Error object written to response
+      expect(setStub).to.have.been.calledWith({
+        completed: true,
+        completedAt: 'test',
+        error: 'Action template is required to run steps',
+        status: 'error'
+      })
+    })
+
+    it('Throws if action template does not contain steps', async () => {
+      const snap = {
+        val: () => ({ projectId: 'test', template: { asdf: 'asdf' } }),
+        ref: refStub()
+      }
+      const fakeContext = {
+        params: { pushId: 1 }
+      }
+      // Invoke with fake event object
+      const [err] = await to(actionRunner(snap, fakeContext))
+      // Response marked as started
+      expect(setStub).to.have.been.calledWith({
+        startedAt: 'test',
+        status: 'started'
+      })
+      // Confir error thrown with correct message
+      expect(err).to.have.property(
+        'message',
+        'Steps array was not provided to action request'
+      )
+      // Ref for response is correct path
+      expect(refStub).to.have.been.calledWith(responsePath)
+      // Error object written to response
+      expect(setStub).to.have.been.calledWith({
+        completed: true,
+        completedAt: 'test',
+        error: 'Steps array was not provided to action request',
+        status: 'error'
+      })
+    })
+
+    it('Throws if action template does not contain inputs', async () => {
+      const snap = {
+        val: () => ({ projectId: 'test', template: { steps: [] } }),
+        ref: refStub()
+      }
+      const fakeContext = {
+        params: { pushId: 1 }
+      }
+      // Invoke with fake event object
+      const [err] = await to(actionRunner(snap, fakeContext))
+      // Response marked as started
+      expect(setStub).to.have.been.calledWith({
+        startedAt: 'test',
+        status: 'started'
+      })
+      // Confir error thrown with correct message
+      expect(err).to.have.property(
+        'message',
+        'Inputs array was not provided to action request'
+      )
+      // Ref for response is correct path
+      expect(refStub).to.have.been.calledWith(responsePath)
+      // Error object written to response
+      expect(setStub).to.have.been.calledWith({
+        completed: true,
+        completedAt: 'test',
+        error: 'Inputs array was not provided to action request',
+        status: 'error'
+      })
+    })
+
+    it('Throws if action template does not contain inputValues', async () => {
+      const snap = {
+        val: () => ({ projectId: 'test', template: { steps: [], inputs: [] } }),
+        ref: refStub()
+      }
+      const fakeContext = {
+        params: { pushId: 1 }
+      }
+      // Invoke with fake event object
+      const [err] = await to(actionRunner(snap, fakeContext))
+      // Response marked as started
+      expect(setStub).to.have.been.calledWith({
+        startedAt: 'test',
+        status: 'started'
+      })
+      // Confir error thrown with correct message
+      expect(err).to.have.property(
+        'message',
+        'Input values array was not provided to action request'
+      )
+      // Ref for response is correct path
+      expect(refStub).to.have.been.calledWith(responsePath)
+      // Error object written to response
+      expect(setStub).to.have.been.calledWith({
+        completed: true,
+        completedAt: 'test',
+        error: 'Input values array was not provided to action request',
+        status: 'error'
+      })
+    })
+
+    it('Throws if inputValues are not passed', async () => {
+      const snap = {
+        val: () => ({
+          projectId: 'test',
+          template: { steps: [], inputs: [] }
+        }),
+        ref: refStub()
+      }
+      const fakeContext = {
+        params: { pushId: 1 }
+      }
+      // Invoke with fake event object
+      const [err] = await to(actionRunner(snap, fakeContext))
+      // Response marked as started
+      expect(setStub).to.have.been.calledWith({
+        startedAt: 'test',
+        status: 'started'
+      })
+      // Confir error thrown with correct message
+      expect(err).to.have.property(
+        'message',
+        'Input values array was not provided to action request'
+      )
+      // Ref for response is correct path
+      expect(refStub).to.have.been.calledWith(responsePath)
+      // Error object written to response
+      expect(setStub).to.have.been.calledWith({
+        completed: true,
+        completedAt: 'test',
+        error: 'Input values array was not provided to action request',
+        status: 'error'
+      })
+    })
+
+    it('Throws if environment does not have databaseURL', async () => {
+      const snap = {
+        val: () => ({
+          projectId: 'test',
+          inputValues: [],
+          environments: [{ type: 'test' }],
+          template: { steps: [], inputs: [] }
+        }),
+        ref: refStub()
+      }
+      const fakeContext = {
+        params: { pushId: 1 }
+      }
+      // Invoke with fake event object
+      const [err] = await to(actionRunner(snap, fakeContext))
+      // Response marked as started
+      expect(setStub).to.have.been.calledWith({
+        startedAt: 'test',
+        status: 'started'
+      })
+      // Confir error thrown with correct message
+      expect(err).to.have.property(
+        'message',
+        'databaseURL is required for action to authenticate through serviceAccount'
+      )
+      // Ref for response is correct path
+      expect(refStub).to.have.been.calledWith(responsePath)
+      // Error object written to response
+      expect(setStub).to.have.been.calledWith({
+        completed: true,
+        completedAt: 'test',
+        error:
+          'databaseURL is required for action to authenticate through serviceAccount',
+        status: 'error'
+      })
+    })
+
+    it('Throws if environment does not an environment key or id', async () => {
+      const snap = {
+        val: () => ({
+          projectId: 'test',
+          inputValues: [],
+          environments: [
+            { databaseURL: 'https://some-project.firebaseio.com' }
+          ],
+          template: { steps: [], inputs: [] }
+        }),
+        ref: refStub()
+      }
+      const fakeContext = {
+        params: { pushId: 1 }
+      }
+      // Invoke with fake event object
+      const [err] = await to(actionRunner(snap, fakeContext))
+      // Response marked as started
+      expect(setStub).to.have.been.calledWith({
+        startedAt: 'test',
+        status: 'started'
+      })
+      // Confir error thrown with correct message
+      expect(err).to.have.property(
+        'message',
+        'environmentKey or id is required for action to authenticate through serviceAccount'
+      )
+      // Ref for response is correct path
+      expect(refStub).to.have.been.calledWith(responsePath)
+      // Error object written to response
+      expect(setStub).to.have.been.calledWith({
+        completed: true,
+        completedAt: 'test',
+        error:
+          'environmentKey or id is required for action to authenticate through serviceAccount',
+        status: 'error'
+      })
+    })
+
+    it('Throws if project does not contain serviceAccount', async () => {
+      const id = 'asdf'
+      const projectId = 'another'
+      const snap = {
+        val: () => ({
+          projectId,
+          inputValues: [],
+          environments: [
+            { databaseURL: 'https://some-project.firebaseio.com', id }
+          ],
+          template: { steps: [], inputs: [] }
+        }),
+        ref: refStub()
+      }
+      const fakeContext = {
+        params: { pushId: 1 }
+      }
+      // Invoke with fake event object
+      const [err] = await to(actionRunner(snap, fakeContext))
+      // Response marked as started
+      expect(setStub).to.have.been.calledWith({
+        startedAt: 'test',
+        status: 'started'
+      })
+      // Confir error thrown with correct message
+      expect(err).to.have.property(
+        'message',
+        `Project containing service account not at path: projects/${projectId}/environments/${id}`
+      )
+      // Ref for response is correct path
+      expect(refStub).to.have.been.calledWith(responsePath)
+      // Error object written to response
+      expect(setStub).to.have.been.calledWith({
+        completed: true,
+        completedAt: 'test',
+        error: `Project containing service account not at path: projects/${projectId}/environments/${id}`,
+        status: 'error'
+      })
+    })
+
+    it('Throws if provided an invalid service account object (i.e. a string that is not an encrypted object)', async () => {
+      const snap = {
+        val: () => ({
+          projectId: existingProjectId,
+          inputValues: [],
+          environments: [
+            { databaseURL: 'https://some-project.firebaseio.com', id: 'asdf' }
+          ],
+          template: { steps: [], inputs: [] }
+        }),
+        ref: refStub()
+      }
+      const fakeContext = {
+        params: { pushId: 1 }
+      }
+      // Invoke with fake event object
+      const [err] = await to(actionRunner(snap, fakeContext))
+      // Response marked as started
+      expect(setStub).to.have.been.calledWith({
+        startedAt: 'test',
+        status: 'started'
+      })
+      // Confir error thrown with correct message
+      expect(err).to.have.property(
+        'message',
+        'Service account not a valid object'
+      )
+      // Ref for response is correct path
+      expect(refStub).to.have.been.calledWith(responsePath)
+      // Error object written to response
+      expect(setStub).to.have.been.calledWith({
+        completed: true,
+        completedAt: 'test',
+        error: 'Service account not a valid object',
+        status: 'error'
+      })
+    })
+
+    it('Throws if template contains invalid steps', async () => {
+      const validProjectId = 'aosidjfoaisjdfoi'
+      docStub.withArgs(`projects/${validProjectId}/environments/asdf`).returns({
+        get: sinon.stub().returns(
+          Promise.resolve({
+            data: () => ({
+              serviceAccount: {
+                credential: encrypt({
+                  type: 'service_account',
+                  project_id: 'asdf',
+                  private_key_id: 'asdf',
+                  private_key: 'asdf',
+                  client_email: 'asdf',
+                  client_id: 'sadf',
+                  auth_uri: 'https://accounts.google.com/o/oauth2/auth',
+                  token_uri: 'https://accounts.google.com/o/oauth2/token',
+                  auth_provider_x509_cert_url:
+                    'https://www.googleapis.com/oauth2/v1/certs',
+                  client_x509_cert_url: 'asdf'
+                })
+              }
+            }),
+            exists: true
+          })
+        )
+      })
+      const snap = {
+        val: () => ({
+          projectId: validProjectId,
+          inputValues: ['projects'],
+          environments: [
             {
-              type: 'copy'
+              databaseURL: 'https://some-project.firebaseio.com',
+              id: 'asdf'
             }
           ],
-          inputs: []
-        }
-      }),
-      ref: refStub()
-    }
-    const fakeContext = {
-      params: { pushId: 1 }
-    }
-    // Invoke with fake event object
-    const [err] = await to(actionRunner(snap, fakeContext))
-    // Response marked as started
-    expect(setStub).to.have.been.calledWith({
-      startedAt: 'test',
-      status: 'started'
-    })
-    // Confirm res
-    expect(err).to.have.property(
-      'message',
-      'Error running step: 0 : src, dest and src.resource are required to run step'
-    )
-    // Ref for response is correct path
-    expect(refStub).to.have.been.calledWith(responsePath)
-    // Success object written to response
-    expect(setStub).to.have.been.calledWith({
-      completed: true,
-      completedAt: 'test',
-      error:
-        'Error running step: 0 : src, dest and src.resource are required to run step',
-      status: 'error'
+          template: {
+            steps: [
+              {
+                type: 'copy'
+              }
+            ],
+            inputs: []
+          }
+        }),
+        ref: refStub()
+      }
+      const fakeContext = {
+        params: { pushId: 1 }
+      }
+      // Invoke with fake event object
+      const [err] = await to(actionRunner(snap, fakeContext))
+      // Response marked as started
+      expect(setStub).to.have.been.calledWith({
+        startedAt: 'test',
+        status: 'started'
+      })
+      // Confirm res
+      expect(err).to.have.property(
+        'message',
+        'Error running step: 0 : src, dest and src.resource are required to run step'
+      )
+      // Ref for response is correct path
+      expect(refStub).to.have.been.calledWith(responsePath)
+      // Success object written to response
+      expect(setStub).to.have.been.calledWith({
+        completed: true,
+        completedAt: 'test',
+        error:
+          'Error running step: 0 : src, dest and src.resource are required to run step',
+        status: 'error'
+      })
     })
   })
-  describe('Action templates with type "copy"', () => {
-    function createValidStubs(projectId) {
+
+  describe('Action template with type "copy"', () => {
+    function createValidActionRunnerStubs(opts) {
+      const {
+        projectId = 'asdfasdf1',
+        srcResource = 'rtdb',
+        destResource = 'rtdb'
+      } =
+        opts || {}
       // Environment Doc Stub (subcollection of project document)
       const environmentDocStub = docStub
         .withArgs(`projects/${projectId}/environments/asdf`)
@@ -586,8 +627,8 @@ describe('actionRunner RTDB Cloud Function (RTDB:onCreate)', function() {
             steps: [
               {
                 type: 'copy',
-                dest: { pathType: 'input', path: 0, resource: 'rtdb' },
-                src: { pathType: 'input', path: 0, resource: 'rtdb' }
+                dest: { pathType: 'input', path: 0, resource: destResource },
+                src: { pathType: 'input', path: 0, resource: srcResource }
               }
             ],
             inputs: [{ type: 'userInput' }]
@@ -600,67 +641,18 @@ describe('actionRunner RTDB Cloud Function (RTDB:onCreate)', function() {
         environmentDocStub
       }
     }
-    describe('with src resource set to "firestore"', () => {
+
+    describe('with src: "firestore" and dest: "firestore"', () => {
       it('successfully copies between Firestore instances', async () => {
-        const validProjectId = 'aosidjfoaisjdfoi'
-        docStub
-          .withArgs(`projects/${validProjectId}/environments/asdf`)
-          .returns({
-            get: sinon.stub().returns(
-              Promise.resolve({
-                data: () => ({
-                  serviceAccount: {
-                    credential: encrypt({
-                      type: 'service_account',
-                      project_id: 'asdf',
-                      private_key_id: 'asdf',
-                      private_key: 'asdf',
-                      client_email: 'asdf',
-                      client_id: 'sadf',
-                      auth_uri: 'https://accounts.google.com/o/oauth2/auth',
-                      token_uri: 'https://accounts.google.com/o/oauth2/token',
-                      auth_provider_x509_cert_url:
-                        'https://www.googleapis.com/oauth2/v1/certs',
-                      client_x509_cert_url: 'asdf'
-                    })
-                  }
-                }),
-                exists: true
-              })
-            )
-          })
-        const snap = {
-          val: () => ({
-            projectId: validProjectId,
-            inputValues: ['projects'],
-            environments: [
-              {
-                databaseURL: 'https://some-project.firebaseio.com',
-                id: 'asdf'
-              },
-              {
-                databaseURL: 'https://some-project.firebaseio.com',
-                id: 'asdf'
-              }
-            ],
-            template: {
-              steps: [
-                {
-                  type: 'copy',
-                  dest: { pathType: 'input', path: 0, resource: 'firestore' },
-                  src: { pathType: 'input', path: 0, resource: 'firestore' }
-                }
-              ],
-              inputs: [{ type: 'userInput' }]
-            }
-          }),
-          ref: refStub()
-        }
+        const { snapStub } = createValidActionRunnerStubs({
+          srcResource: 'firestore',
+          destResource: 'firestore'
+        })
         const fakeContext = {
           params: { pushId: 1 }
         }
         // Invoke with fake event object
-        const res = await actionRunner(snap, fakeContext)
+        const res = await actionRunner(snapStub, fakeContext)
         // Response marked as started
         expect(setStub).to.have.been.calledWith({
           startedAt: 'test',
@@ -678,10 +670,39 @@ describe('actionRunner RTDB Cloud Function (RTDB:onCreate)', function() {
         })
       })
     })
-    describe('with src resource set to "rtdb"', () => {
+
+    describe('with src: "firestore" and dest: "rtdb"', () => {
+      it('successfully copies from Firestore to Real Time Database', async () => {
+        const { snapStub } = createValidActionRunnerStubs({
+          srcResource: 'firestore',
+          destResource: 'rtdb'
+        })
+        const fakeContext = {
+          params: { pushId: 1 }
+        }
+        // Invoke with fake event object
+        const res = await actionRunner(snapStub, fakeContext)
+        // Response marked as started
+        expect(setStub).to.have.been.calledWith({
+          startedAt: 'test',
+          status: 'started'
+        })
+        // Confirm res
+        expect(res).to.be.null
+        // Ref for response is correct path
+        expect(refStub).to.have.been.calledWith(responsePath)
+        // Success object written to response
+        expect(setStub).to.have.been.calledWith({
+          completed: true,
+          completedAt: 'test',
+          status: 'success'
+        })
+      })
+    })
+
+    describe('with src "rtdb" and dest: "rtdb"', () => {
       it('successfully copies between RTDB instances', async () => {
-        const validProjectId = 'aosidjfoaisjdfoi'
-        const { snapStub } = createValidStubs(validProjectId)
+        const { snapStub } = createValidActionRunnerStubs()
         const fakeContext = {
           params: { pushId: 1 }
         }
@@ -704,9 +725,97 @@ describe('actionRunner RTDB Cloud Function (RTDB:onCreate)', function() {
         })
       })
     })
+
+    describe('with src: "rtdb" and dest: "firestore"', () => {
+      it('successfully copies from RTDB to Firestore', async () => {
+        const { snapStub } = createValidActionRunnerStubs({
+          srcResource: 'rtdb',
+          destResource: 'firestore'
+        })
+        const fakeContext = {
+          params: { pushId: 1 }
+        }
+        // Invoke with fake event object
+        const res = await actionRunner(snapStub, fakeContext)
+        // Response marked as started
+        expect(setStub).to.have.been.calledWith({
+          startedAt: 'test',
+          status: 'started'
+        })
+        // Confirm res
+        expect(res).to.be.undefined
+        // Ref for response is correct path
+        expect(refStub).to.have.been.calledWith(responsePath)
+        // Success object written to response
+        expect(setStub).to.have.been.calledWith({
+          completed: true,
+          completedAt: 'test',
+          status: 'success'
+        })
+      })
+    })
+
+    describe('with src: "rtdb" and dest: "storage"', () => {
+      it('successfully copies from RTDB to Cloud Storage', async () => {
+        const { snapStub } = createValidActionRunnerStubs({
+          srcResource: 'rtdb',
+          destResource: 'storage'
+        })
+        const fakeContext = {
+          params: { pushId: 1 }
+        }
+        // Invoke with fake event object
+        const res = await actionRunner(snapStub, fakeContext)
+        // Response marked as started
+        expect(setStub).to.have.been.calledWith({
+          startedAt: 'test',
+          status: 'started'
+        })
+        // Confirm res
+        expect(res).to.be.undefined
+        // Ref for response is correct path
+        expect(refStub).to.have.been.calledWith(responsePath)
+        // Success object written to response
+        expect(setStub).to.have.been.calledWith({
+          completed: true,
+          completedAt: 'test',
+          status: 'success'
+        })
+      })
+    })
+
+    describe('with src: "storage" and dest: "rtdb"', () => {
+      it('successfully copies from Cloud Storage to RTDB', async () => {
+        const { snapStub } = createValidActionRunnerStubs({
+          srcResource: 'storage',
+          destResource: 'rtdb'
+        })
+        const fakeContext = {
+          params: { pushId: 1 }
+        }
+        // Invoke with fake event object
+        const res = await actionRunner(snapStub, fakeContext)
+        // Response marked as started
+        expect(setStub).to.have.been.calledWith({
+          startedAt: 'test',
+          status: 'started'
+        })
+        // Confirm res
+        expect(res).to.be.undefined
+        // Ref for response is correct path
+        expect(refStub).to.have.been.calledWith(responsePath)
+        // Success object written to response
+        expect(setStub).to.have.been.calledWith({
+          completed: true,
+          completedAt: 'test',
+          status: 'success'
+        })
+      })
+    })
   })
-  describe('backups', () => {
-    it('Works with backups', async () => {
+
+  describe('Action template with backups', () => {
+    it('Calls backups before running steps', async () => {
       const snap = {
         val: () => ({
           projectId: 'test',

--- a/functions/test/unit/copyServiceAccountToFirestore.spec.js
+++ b/functions/test/unit/copyServiceAccountToFirestore.spec.js
@@ -7,6 +7,7 @@ describe('copyServiceAccountToFirestore Firestore Cloud Function (onCreate)', ()
   let refStub // eslint-disable-line no-unused-vars
   let docSetStub // eslint-disable-line no-unused-vars
   let adminInitStub
+  let storageAdminStub
 
   before(() => {
     // Stub Firebase's admin.initializeApp()
@@ -22,13 +23,22 @@ describe('copyServiceAccountToFirestore Firestore Cloud Function (onCreate)', ()
     // Set GCLOUD_PROJECT to env
     process.env.GCLOUD_PROJECT = 'test'
     const storageStub = sinon.stub().returns({
-      bucket: {
+      bucket: sinon.stub().returns({
         file: sinon.stub().returns({
-          download: sinon.stub().returns(Promise.resolve({}))
+          delete: sinon.stub().returns(Promise.resolve({})),
+          // Mock download method with invalid JSON file data
+          download: sinon.spy(({ destination }) => {
+            fs.writeFileSync(
+              destination,
+              JSON.stringify({ asdf: 'asdf' }, null, 2)
+            )
+            return Promise.resolve({ asdf: 'asdf' })
+          })
         })
-      }
+      })
     })
-    sinon.stub(admin, 'storage').get(() => storageStub)
+    storageAdminStub = sinon.stub(admin, 'storage').get(() => storageStub)
+
     // Load wrapped version of Cloud Function
     /* eslint-disable global-require */
     copyServiceAccountToFirestore = functionsTest.wrap(
@@ -40,6 +50,7 @@ describe('copyServiceAccountToFirestore Firestore Cloud Function (onCreate)', ()
   afterEach(() => {
     // Restoring stubs to the original methods
     functionsTest.cleanup()
+    storageAdminStub.restore()
   })
 
   it('throws if service account paramter is not provided', async () => {
@@ -61,8 +72,10 @@ describe('copyServiceAccountToFirestore Firestore Cloud Function (onCreate)', ()
     const fakeEvent = {
       data: () => fakeEventData
     }
+
+    // Modified stub with error to run over existing
     const storageStub = sinon.stub().returns({
-      bucket: {
+      bucket: sinon.stub().returns({
         file: sinon.stub().returns({
           // Mock download method with promise rejection matching cloud storage
           download: sinon
@@ -71,9 +84,9 @@ describe('copyServiceAccountToFirestore Firestore Cloud Function (onCreate)', ()
               Promise.reject(new Error('A file name must be specified.'))
             )
         })
-      }
+      })
     })
-    sinon.stub(admin, 'storage').get(() => storageStub)
+    storageAdminStub = sinon.stub(admin, 'storage').get(() => storageStub)
     const fakeContext = { params: { projectId: 'abc123' } }
     const [err] = await to(
       copyServiceAccountToFirestore(fakeEvent, fakeContext)
@@ -87,54 +100,39 @@ describe('copyServiceAccountToFirestore Firestore Cloud Function (onCreate)', ()
       data: () => fakeEventData
     }
     const fakeContext = { params: { projectId: 'abc123' } }
+
+    // Modified stub with error to run over existing
     const storageStub = sinon.stub().returns({
-      bucket: {
+      bucket: sinon.stub().returns({
         file: sinon.stub().returns({
           // Mock download method with promise rejection matching cloud storage
           download: sinon.stub().returns(Promise.reject(new Error('Not Found')))
         })
-      }
+      })
     })
-    sinon.stub(admin, 'storage').get(() => storageStub)
+    storageAdminStub = sinon.stub(admin, 'storage').get(() => storageStub)
     const [err] = await to(
       copyServiceAccountToFirestore(fakeEvent, fakeContext)
     )
     expect(err).to.have.property('message', 'Not Found')
   })
 
-  // Skipped due to issues mocking Google Cloud Storage library
-  // TODO: Unskip once GCS is switched with Firebase's admin.storage()
-  it.skip('throws if downloaded service account file can not be read as JSON', async () => {
-    const fakeEventData = { serviceAccount: { fullPath: 'test' } }
-    const storageStub = sinon.stub().returns({
-      bucket: {
-        file: sinon.stub().returns({
-          // Mock download method with invalid JSON file data
-          download: sinon.spy(({ destination }) => {
-            fs.writeFileSync(destination, JSON.stringify({ asdf: 'asdf' }))
-            return Promise.resolve()
-          })
-        })
-      }
-    })
-    sinon.stub(admin, 'storage').get(() => storageStub)
-    const fakeEvent = {
-      data: () => fakeEventData,
-      ref: {
-        update: sinon.stub().returns(Promise.resolve({}))
-      }
-    }
-    const fakeContext = { params: { projectId: 'abc123' } }
-    const [err] = await to(
-      copyServiceAccountToFirestore(fakeEvent, fakeContext)
-    )
-    expect(err).to.have.property('message', 'Error saving file as JSON')
-    admin.storage.restore()
-  })
+  // it('throws if downloaded service account file can not be read as JSON', async () => {
+  //   const fakeEventData = { serviceAccount: { fullPath: 'test' } }
+  //   const fakeEvent = {
+  //     data: () => fakeEventData,
+  //     ref: {
+  //       update: sinon.stub().returns(Promise.resolve({}))
+  //     }
+  //   }
+  //   const fakeContext = { params: { projectId: 'abc123' } }
 
-  // Skipped due to issues mocking Google Cloud Storage library
-  // TODO: Unskip once GCS is switched with Firebase's admin.storage()
-  it.skip('updates reference with serviceAccount param', async () => {
+  //   // Run wrapped function
+  //   const res = await copyServiceAccountToFirestore(fakeEvent, fakeContext)
+  //   expect(res).to.be.null
+  // })
+
+  it('updates reference with serviceAccount param', async () => {
     const fakeEventData = { serviceAccount: { fullPath: 'test' } }
 
     const fakeEvent = {
@@ -144,9 +142,7 @@ describe('copyServiceAccountToFirestore Firestore Cloud Function (onCreate)', ()
       }
     }
     const fakeContext = { params: { projectId: 'abc123' } }
-    const [err] = await to(
-      copyServiceAccountToFirestore(fakeEvent, fakeContext)
-    )
-    expect(err).to.have.property('message', 'Error saving file as JSON')
+    const res = await copyServiceAccountToFirestore(fakeEvent, fakeContext)
+    expect(res).to.be.null
   })
 })

--- a/functions/test/unit/copyServiceAccountToFirestore.spec.js
+++ b/functions/test/unit/copyServiceAccountToFirestore.spec.js
@@ -117,21 +117,6 @@ describe('copyServiceAccountToFirestore Firestore Cloud Function (onCreate)', ()
     expect(err).to.have.property('message', 'Not Found')
   })
 
-  // it('throws if downloaded service account file can not be read as JSON', async () => {
-  //   const fakeEventData = { serviceAccount: { fullPath: 'test' } }
-  //   const fakeEvent = {
-  //     data: () => fakeEventData,
-  //     ref: {
-  //       update: sinon.stub().returns(Promise.resolve({}))
-  //     }
-  //   }
-  //   const fakeContext = { params: { projectId: 'abc123' } }
-
-  //   // Run wrapped function
-  //   const res = await copyServiceAccountToFirestore(fakeEvent, fakeContext)
-  //   expect(res).to.be.null
-  // })
-
   it('updates reference with serviceAccount param', async () => {
     const fakeEventData = { serviceAccount: { fullPath: 'test' } }
 

--- a/functions/test/unit/storageFileToRTDB.spec.js
+++ b/functions/test/unit/storageFileToRTDB.spec.js
@@ -1,6 +1,7 @@
 import * as admin from 'firebase-admin' // eslint-disable-line no-unused-vars
 import fauxJax from 'faux-jax'
 import { to } from 'utils/async'
+import fs from 'fs'
 
 describe('storageFileToRTDB RTDB Cloud Function (database:onCreate)', () => {
   let storageFileToRTDB
@@ -11,6 +12,8 @@ describe('storageFileToRTDB RTDB Cloud Function (database:onCreate)', () => {
   let setStub
   let databaseStub
   let firestoreStub
+  let storageAdminStub
+  let fakeContext
 
   beforeEach(() => {
     // Stub Firebase's functions.config() (default in test/setup)
@@ -31,6 +34,23 @@ describe('storageFileToRTDB RTDB Cloud Function (database:onCreate)', () => {
     docStub.returns({ set: docSetStub })
     firestoreStub.returns({ doc: docStub })
     sinon.stub(admin, 'database').get(() => databaseStub)
+
+    const storageStub = sinon.stub().returns({
+      bucket: sinon.stub().returns({
+        file: sinon.stub().returns({
+          delete: sinon.stub().returns(Promise.resolve({})),
+          // Mock download method with invalid JSON file data
+          download: sinon.spy(({ destination }) => {
+            fs.writeFileSync(
+              destination,
+              JSON.stringify({ asdf: 'asdf' }, null, 2)
+            )
+            return Promise.resolve({ asdf: 'asdf' })
+          })
+        })
+      })
+    })
+    storageAdminStub = sinon.stub(admin, 'storage').get(() => storageStub)
     // Intercept all http requests and respond with 200
     fauxJax.install()
     fauxJax.on('request', function respond(request) {
@@ -47,6 +67,9 @@ describe('storageFileToRTDB RTDB Cloud Function (database:onCreate)', () => {
       databaseURL: 'https://some-project.firebaseio.com',
       storageBucket: 'some-bucket.appspot.com'
     })
+    fakeContext = {
+      params: { projectId: 'asdf', environmentId: 'asdf' }
+    }
   })
 
   afterEach(() => {
@@ -54,23 +77,52 @@ describe('storageFileToRTDB RTDB Cloud Function (database:onCreate)', () => {
     adminInitStub.restore()
     // Restore http request functionality
     fauxJax.restore()
+    storageAdminStub.restore()
   })
 
   describe('Storage File to RTDB', () => {
-    // TODO: UNSKIP
-    // Currently skipped due to:
-    // Error: Could not refresh access token.
-    it('responds to fake event', async () => {
+    it('throws for a missing filePath', async () => {
       const snap = {
-        val: () => ({ displayName: 'some', filePath: 'some' })
-      }
-      const fakeContext = {
-        params: { filePath: 'testing', userId: 1 }
+        val: () => ({ databasePath: 'some' })
       }
       // Invoke webhook with our fake request and response objects. This will cause the
       // assertions in the response object to be evaluated.
       const [err] = await to(storageFileToRTDB(snap, fakeContext))
-      expect(err).to.have.property('message', 'Could not refresh access token.')
+      expect(err).to.have.property(
+        'message',
+        `"filePath" and "databasePath" are required to copy file to RTDB`
+      )
+    })
+
+    it('throws for a missing databasePath', async () => {
+      const snap = {
+        val: () => ({ filePath: 'some' })
+      }
+      // Invoke webhook with our fake request and response objects. This will cause the
+      // assertions in the response object to be evaluated.
+      const [err] = await to(storageFileToRTDB(snap, fakeContext))
+      expect(err).to.have.property(
+        'message',
+        `"filePath" and "databasePath" are required to copy file to RTDB`
+      )
+    })
+
+    it('resolves with filePath after completing successfully', async () => {
+      const filePath = 'someFilePath'
+      const databasePath = 'someDbPath'
+      const snap = {
+        val: () => ({ filePath, databasePath }),
+        ref: {
+          root: {
+            child: sinon.stub().returns({
+              set: sinon.stub().returns(Promise.resolve())
+            })
+          }
+        }
+      }
+      // Invoke cloud function with fake data
+      const res = await storageFileToRTDB(snap, fakeContext)
+      expect(res).to.equal(filePath)
     })
   })
 })


### PR DESCRIPTION
### Description
* feat(functions): `@google-cloud/storage` replaced with `admin.storage()` from `firebase-admin`
* feat(functions): tests updated to cover cloud functions functionality ~70%

### Check List

- [X] All test passed
- [X] Updated Any Relevant Docs
