### PR TITLE
v0.6.3

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "fireadmin",
-  "version": "0.6.2",
+  "version": "0.6.3",
   "description": "Application for Managing Firebase Applications. Includes support for multiple environments and data migrations.",
   "main": "index.js",
   "scripts": {


### PR DESCRIPTION
### Description
* fix(sendFcm): use `admin.messaging` to send message instead of calling Firebase messaging API directly

### Check List

- [X] All test passed
- [X] Updated Any Relevant Docs
